### PR TITLE
Dont crash lag views if consumer group offsets didn't exist in burrow

### DIFF
--- a/client/components/merged-lag-stats.js
+++ b/client/components/merged-lag-stats.js
@@ -30,8 +30,12 @@ export default React.createClass({
   },
 
   chartData() {
-    this.props.consumers.forEach(cache.refreshTotalLag)
-    const consumerNames = this.props.consumers.map(entry => entry.name)
+    let consumers = this.props.consumers
+      .filter(
+        (consumer) => {return !!consumer.consumer_group.offsets}
+      )
+    consumers.forEach(cache.refreshTotalLag)
+    const consumerNames = consumers.map(entry => entry.name)
     const caches = consumerNames.map(cache.readTotalLag)
     const labels = caches[0].series.map(chartLabel)
 

--- a/client/components/status-widget.js
+++ b/client/components/status-widget.js
@@ -1,0 +1,13 @@
+import React from 'react'
+import Widget from './widget'
+
+export default React.createClass({
+  render() {
+    return (
+      <Widget className='status-widget-view' name={this.props.name}>
+        <span className="status-label">{this.props.status}</span>
+      </Widget>
+    )
+  }
+
+})

--- a/client/components/status-widget.scss
+++ b/client/components/status-widget.scss
@@ -1,0 +1,9 @@
+.status-widget-view {
+  margin: 10px 0 60px 0;
+
+  .status-label {
+    padding-left: 20px;
+    color: #a9a9a9;
+    font-size: x-large;
+  }
+}

--- a/client/views/consumer-lag-view.js
+++ b/client/views/consumer-lag-view.js
@@ -5,6 +5,7 @@ import APIStatus from '../components/api-status'
 import TotalLagStats from '../components/total-lag-stats'
 import MergedLagStats from '../components/merged-lag-stats'
 import Spinner from '../components/spinner'
+import StatusWidget from '../components/status-widget'
 import Toggle from 'material-ui/Toggle';
 import burrowStatsOptions from '../utils/burrow-stats-options'
 
@@ -74,7 +75,11 @@ export default React.createClass({
     return this.state
       .data
       .map((consumerData) => {
-        return <TotalLagStats key={consumerData.name} {...consumerData} />
+        if (!consumerData.consumer_group.offsets){
+          return <StatusWidget key={consumerData.name} name={consumerData.name} status='Consumer Group Inactive' />
+        } else {
+          return <TotalLagStats key={consumerData.name} {...consumerData} />
+        }
       })
   }
 })

--- a/client/views/partitions-lag-view.js
+++ b/client/views/partitions-lag-view.js
@@ -4,6 +4,7 @@ import API from '../api'
 
 import APIStatus from '../components/api-status'
 import PartitionLagStats from '../components/partition-lag-stats'
+import StatusWidget from '../components/status-widget'
 import Spinner from '../components/spinner'
 import burrowStatsOptions from '../utils/burrow-stats-options'
 
@@ -49,7 +50,11 @@ export default React.createClass({
     return this.state
       .data
       .map((consumerData) => {
-        return <PartitionLagStats key={consumerData.name} {...consumerData} />
+        if (!consumerData.consumer_group.offsets){
+          return <StatusWidget key={consumerData.name} name={consumerData.name} status='Consumer Group Inactive' />
+        } else {
+          return <PartitionLagStats key={consumerData.name} {...consumerData} />
+        }
       })
   }
 })


### PR DESCRIPTION
Solves #4 

If no consumer group offsets could be retrieved, show a status widget explaining this instead of crashing the lag view.